### PR TITLE
[TASK] Adjust psr/log-version and update reading of OpcacheStore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": ">=5.5",
     "guzzlehttp/guzzle": ">=6.3.3",
-    "psr/log": "1.0.2"
+    "psr/log": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Store/OpcacheStore.php
+++ b/src/Store/OpcacheStore.php
@@ -109,7 +109,7 @@ class OpcacheStore extends MemoryStore
   protected function readData()
   {
     if (!isset($this->store)) {
-      $this->store = @include($this->fileName) ?: [];
+      $this->store = file_exists($this->fileName) ? include($this->fileName) : [];
     }
   }
 


### PR DESCRIPTION
For Neos Flow 7.3 psr/log version >=2.0 is necessary.

In PHP 8.0 it is not possible to suppress some errors. This happened with the include-method. Therefore I use the file_exist-method  to check this.